### PR TITLE
Add license info in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   ],
   "repository": "git://github.com/mrluc/owl-deepcopy",
   "version": "0.0.6",
+  "license": "LGPLv3",
   "main": "./deep_copy.js",
   "engines": {
     "node": ">=0.4.0"


### PR DESCRIPTION
Issue #3 mentions that this is under LGPLv3, but this is not visible to NPM or tools like VersionEye